### PR TITLE
Fix relation handling

### DIFF
--- a/charms/mariadb/reactive/mysql.py
+++ b/charms/mariadb/reactive/mysql.py
@@ -1,5 +1,5 @@
 from charms.reactive import when, when_not
-from charms.reactive.flags import set_flag, get_state
+from charms.reactive.flags import set_flag, get_state, clear_flag
 from charmhelpers.core.hookenv import (
     log,
     metadata,
@@ -64,6 +64,7 @@ def make_pod_spec():
     return pod_spec_template % data
 
 
+@when('mysql.configured')
 @when('server.database.requested')
 def provide_database(mysql):
     log('db requested')
@@ -86,3 +87,4 @@ def provide_database(mysql):
             user=user,
             password=password,
         )
+        clear_flag('server.database.requested')


### PR DESCRIPTION
Hi Ian,

This fixes two issues related to the handling of the mysql relation, one being the [juju agent performance](https://discourse.jujucharms.com/t/juju-agent-performance-issues/328) I noted on discourse.

- Clear the relation's .requested flag once the db has been provided. This stops the requested hook from being constantly re-run.

- Check that the mysql.configured flag is set before providing the
database. When deploying the charm locally, this will prevent
provide_database from running before an image resource is provided.